### PR TITLE
Improve the usability of Build-ContainerImage

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
+++ b/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
@@ -85,8 +85,6 @@ namespace Docker.PowerShell.Cmdlets
         /// </summary>
         protected override void StopProcessing()
         {
-            base.StopProcessing();
-
             CancelSignal.Cancel();
         }
 

--- a/src/Docker.PowerShell/Cmdlets/JsonMessageWriter.cs
+++ b/src/Docker.PowerShell/Cmdlets/JsonMessageWriter.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+using Docker.PowerShell.Objects;
+using Newtonsoft.Json;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal class JsonMessageWriter
+    {
+        public JsonMessageWriter(PSCmdlet cmdlet)
+        {
+            _cmdlet = cmdlet;
+        }
+
+        public async Task WriteJsonMessages(Stream stream)
+        {
+            using (var progressReader = new StreamReader(stream, new UTF8Encoding(false)))
+            {
+                string line;
+                while ((line = await progressReader.ReadLineAsync()) != null)
+                {
+                    var message = JsonConvert.DeserializeObject<JsonMessage>(line);
+                    WriteJsonMessage(message);
+                }
+            }
+        }
+
+        public void WriteJsonMessage(JsonMessage message)
+        {
+            if (message.Error != null)
+            {
+                var error = new ErrorRecord(new Exception(message.Error.Message), null, ErrorCategory.OperationStopped, null);
+                _cmdlet.WriteError(error);
+            }
+            else if (message.Progress != null)
+            {
+                var id = message.ID ?? "";
+                int activity;
+                if (!_idToActivity.TryGetValue(id, out activity))
+                {
+                    activity = _nextActivity;
+                    _nextActivity++;
+                    _idToActivity.Add(id, activity);
+                }
+
+                var activityName = new StringBuilder(id);
+                if (activityName.Length == 0)
+                {
+                    activityName.Append("Operation");
+                }
+
+                if (message.From != null)
+                {
+                    activityName.AppendFormat("(from {0})", message.From);
+                }
+
+                var record = new ProgressRecord(activity, activityName.ToString(), message.Status ?? "Processing");
+
+                var progress = message.Progress;
+                if (progress.Total > 0)
+                {
+                    record.PercentComplete = (int)(progress.Current * 100 / progress.Total);
+                }
+
+                if (progress.Current > 0)
+                {
+                    record.CurrentOperation = string.Format(" ({0} bytes)", progress.Current);
+                }
+
+                _cmdlet.WriteProgress(record);
+            }
+            else
+            {
+                var info = new StringBuilder();
+                if (message.ID != null)
+                {
+                    info.Append(message);
+                    info.Append(": ");
+                }
+
+                if (message.From != null)
+                {
+                    info.AppendFormat("(from {0})", message.From);
+                }
+
+                var infoRecord = new HostInformationMessage();
+                if (message.Stream != null)
+                {
+                    info.Append(message.Stream);
+                    infoRecord.NoNewLine = true;
+                }
+                else
+                {
+                    info.Append(message.Status);
+                }
+
+                infoRecord.Message = info.ToString();
+                _cmdlet.WriteInformation(infoRecord, new string[] { "PSHOST" });
+            }
+        }
+
+        public void ClearProgress()
+        {
+            foreach (var activity in _idToActivity)
+            {
+                var record = new ProgressRecord(activity.Value, "Operation", "Processing");
+                record.RecordType = ProgressRecordType.Completed;
+                _cmdlet.WriteProgress(record);
+            }
+        }
+
+        private Dictionary<string, int> _idToActivity = new Dictionary<string, int>();
+        private int _nextActivity = 0x10000;
+        private PSCmdlet _cmdlet;
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/ProgressReader.cs
+++ b/src/Docker.PowerShell/Cmdlets/ProgressReader.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal class ProgressReader : Stream
+    {
+        public struct Status
+        {
+            public bool Complete;
+            public long TotalBytesRead;
+        }
+
+        public ProgressReader(Stream stream, IProgress<Status> progress, long byteDelta = 0)
+        {
+            _stream = stream;
+            _progress = progress;
+            _byteDelta = byteDelta;
+        }
+
+        private Stream _stream;
+        private IProgress<Status> _progress;
+        private Status _status;
+        private long _lastReport = 0;
+        private long _byteDelta = 0;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length { get { throw new NotImplementedException(); } }
+
+        public override long Position
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = _stream.Read(buffer, offset, count);
+            Update(read);
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int read = await _stream.ReadAsync(buffer, offset, count, cancellationToken);
+            Update(read);
+            return read;
+        }
+
+        private void Update(int read)
+        {
+            if (read == 0)
+            {
+                _status.Complete = true;
+            }
+
+            _status.TotalBytesRead += read;
+            if (_status.Complete || _lastReport + _byteDelta <= _status.TotalBytesRead)
+            {
+                _progress.Report(_status);
+                _lastReport = _status.TotalBytesRead;
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This change adds progress bars for Build-ContainerImage, ensures that
Ctrl-C will properly cancel the operation, and factors out JSON message
parsing to be shared for future use in Pull-ContainerImage, etc.