### PR TITLE
Improve Build-ContainerImage pipe handling

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/Archiver.cs
+++ b/src/Docker.PowerShell/Cmdlets/Archiver.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Tar;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal static class Archiver
+    {
+        public static Stream CreateTarStream(string path, CancellationToken cancellationToken)
+        {
+            var pipe = new Pipe();
+            var reader = new PipeReadStream(pipe);
+            try
+            {
+                var tarTask = Task.Run(async () =>
+                {
+                    using (var writer = new PipeWriteStream(pipe))
+                    {
+                        try
+                        {
+                            var tar = new TarWriter(writer);
+                            await tar.CreateEntriesFromDirectoryAsync(path, ".", cancellationToken);
+                        }
+                        catch (Exception e)
+                        {
+                            writer.Close(e);
+                            throw;
+                        }
+
+                        writer.Close();
+                    }
+                }, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                reader.Close(e);
+                throw;
+            }
+
+            return reader;
+        }
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
+++ b/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
@@ -20,7 +20,9 @@ namespace Docker.PowerShell.Cmdlets
     {
         #region Private members
 
-        protected CancellationTokenSource CancelSignal = new CancellationTokenSource();
+        private CancellationTokenSource CancelSignal = new CancellationTokenSource();
+
+        protected CancellationToken CmdletCancellationToken => CancelSignal.Token;
 
         protected DockerClient DkrClient
         {

--- a/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
@@ -65,7 +65,7 @@ namespace Docker.PowerShell.Cmdlets
 
                     var waitResponse = await DkrClient.Containers.WaitContainerAsync(
                         createResult.ID,
-                        CancelSignal.Token);
+                        CmdletCancellationToken);
 
                     WriteVerbose("Status Code: " + waitResponse.StatusCode.ToString());
                     ContainerOperations.ThrowOnProcessExitCode(waitResponse.StatusCode);

--- a/src/Docker.PowerShell/Cmdlets/Pipe.cs
+++ b/src/Docker.PowerShell/Cmdlets/Pipe.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal class Pipe
+    {
+        // The ring buffer.
+        private byte[] _buffer;
+        // The current insertion and removal pointers in the ring buffer.
+        int _in, _out;
+        // The endpoints.
+        Endpoint _reader, _writer;
+        bool _eof;
+        // The lock protecting all the internal state.
+        object _mutex = new object();
+
+        private struct Endpoint
+        {
+            public TaskCompletionSource<int> PendingTask;
+            public ArraySegment<byte> PendingBuffer;
+            public Exception Failure;
+
+            public TaskCompletionSource<int> ReleaseTask()
+            {
+                var task = PendingTask;
+                PendingTask = null;
+                PendingBuffer = new ArraySegment<byte>();
+                return task;
+            }
+        }
+
+        public Pipe(int bufferSize = 65536)
+        {
+            if (bufferSize == 0)
+            {
+                // SpaceLeft() needs a buffer size of at least 1.
+                bufferSize = 1;
+            }
+
+            _buffer = new byte[bufferSize];
+        }
+
+        // Number of free bytes in the ring.
+        private int SpaceLeft()
+        {
+            // The ring buffer cannot be filled completely since that state would
+            // be indistinguishable from an empty ring, so subtract one byte from
+            // the total capacity.
+            return _buffer.Length - DataLeft() - 1;
+        }
+
+        // Number of data bytes in the ring.
+        private int DataLeft()
+        {
+            return (_in >= _out) ? (_in - _out) : (_buffer.Length - (_out - _in));
+        }
+
+        // Copy between two array segments and return the number of bytes copied.
+        private static int Copy(ArraySegment<byte> dest, ArraySegment<byte> source)
+        {
+            int count = Math.Min(dest.Count, source.Count);
+            for (int i = 0; i < count; i++)
+            {
+                dest.Array[dest.Offset + i] = source.Array[source.Offset + i];
+            }
+
+            return count;
+        }
+
+        private static ArraySegment<byte> Advance(ArraySegment<byte> segment, int count)
+        {
+            return new ArraySegment<byte>(segment.Array, segment.Offset + count, segment.Count - count);
+        }
+
+        // Copies data into the ring and returns the number of bytes copied.
+        private int CopyIn(ArraySegment<byte> source)
+        {
+            int i = 0;
+            var inp = _in;
+            var outp = _out;
+            if (inp >= outp)
+            {
+                while (inp < _buffer.Length && i < source.Count)
+                {
+                    _buffer[inp] = source.Array[source.Offset + i];
+                    i++;
+                    inp++;
+                }
+
+                if (inp == _buffer.Length)
+                {
+                    inp = 0;
+                }
+            }
+
+            while (inp + 1 < outp && i < source.Count)
+            {
+                _buffer[inp] = source.Array[source.Offset + i];
+                i++;
+                inp++;
+            }
+
+            _in = inp;
+            return i;
+        }
+
+        // Copy bytes out of the ring and return the number of bytes copied.
+        private int CopyOut(ArraySegment<byte> dest)
+        {
+            int i = 0;
+            var inp = _in;
+            var outp = _out;
+            if (outp > inp)
+            {
+                while (outp < _buffer.Length && i < dest.Count)
+                {
+                    dest.Array[dest.Offset + i] = _buffer[outp];
+                    i++;
+                    outp++;
+                }
+
+                if (outp == _buffer.Length)
+                {
+                    outp = 0;
+                }
+            }
+
+            while (outp < inp && i < dest.Count)
+            {
+                dest.Array[dest.Offset + i] = _buffer[outp];
+                i++;
+                outp++;
+            }
+
+            _out = outp;
+            return i;
+        }
+
+        private Task WriteInternal(ArraySegment<byte> data, CancellationToken cancellationToken, out TaskCompletionSource<int> signaledTask, out int bytesCopied)
+        {
+            signaledTask = null;
+            bytesCopied = 0;
+            lock (_mutex)
+            {
+                if (_reader.Failure != null)
+                {
+                    throw _reader.Failure;
+                }
+
+                if (_writer.Failure != null || _eof)
+                {
+                    throw new InvalidOperationException("pipe already closed");
+                }
+
+                if (_writer.PendingTask != null)
+                {
+                    throw new InvalidOperationException("multiple concurrent writes not supported");
+                }
+
+                // Satisfy the pending reader first.
+                if (_reader.PendingTask != null)
+                {
+                    int copied = Copy(_reader.PendingBuffer, data);
+                    signaledTask = _reader.ReleaseTask();
+                    bytesCopied = copied;
+                    if (copied == data.Count)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    // There is more data than fit in the reader's buffer.
+                    data = Advance(data, copied);
+                }
+
+                // Copy data into the ring only if all of it fits. There is no sense buffering if
+                // we have to block anyway.
+                if (SpaceLeft() >= data.Count)
+                {
+                    CopyIn(data);
+                    return Task.CompletedTask;
+                }
+
+                // We must block. Allocate a new task to do the blocking.
+                var taskSource = new TaskCompletionSource<int>();
+
+                // Register a cancellation callback that dequeues the task.
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationToken.Register(() => CancelTask(ref _writer, taskSource));
+                }
+
+                _writer.PendingTask = taskSource;
+                _writer.PendingBuffer = data;
+                return taskSource.Task;
+            }
+        }
+
+        public Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int copied;
+            TaskCompletionSource<int> signaledTask;
+            var data = new ArraySegment<byte>(buffer, offset, count);
+            var task = WriteInternal(data, cancellationToken, out signaledTask, out copied);
+            if (signaledTask != null)
+            {
+                signaledTask.SetResult(copied);
+            }
+
+            return task;
+        }
+
+        private Task<int> ReadInternal(ArraySegment<byte> data, CancellationToken cancellationToken, out TaskCompletionSource<int> signaledTask)
+        {
+            signaledTask = null;
+            lock (_mutex)
+            {
+                if (_writer.Failure != null)
+                {
+                    throw _writer.Failure;
+                }
+
+                if (_reader.Failure != null)
+                {
+                    throw new InvalidOperationException("pipe already closed");
+                }
+
+                if (_reader.PendingTask != null)
+                {
+                    throw new InvalidOperationException("multiple concurrent reads not supported");
+                }
+
+                // If there is data in the ring, consume it directly. For simplicity, do not
+                // consume writer data if there is ring data; the caller can call back again.
+                if (_in != _out)
+                {
+                    return Task.FromResult(CopyOut(data));
+                }
+
+                if (_eof)
+                {
+                    // Return 0 to indicate EOF.
+                    return Task.FromResult(0);
+                }
+
+                // If there is a writer, copy its data into the buffer.
+                if (_writer.PendingTask != null)
+                {
+                    int copied = Copy(data, _writer.PendingBuffer);
+                    if (copied == _writer.PendingBuffer.Count)
+                    {
+                        signaledTask = _writer.ReleaseTask();
+                    }
+                    else
+                    {
+                        // The writer still has data left. Copy it into the ring buffer if
+                        // doing so would unblock the writer.
+                        var remainingData = Advance(_writer.PendingBuffer, copied);
+                        if (remainingData.Count <= SpaceLeft())
+                        {
+                            CopyIn(remainingData);
+                            signaledTask = _writer.ReleaseTask();
+                        }
+                        else
+                        {
+                            _writer.PendingBuffer = remainingData;
+                        }
+                    }
+
+                    return Task.FromResult(copied);
+                }
+
+                var taskSource = new TaskCompletionSource<int>();
+
+                // Register a cancellation callback that dequeues the task.
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationToken.Register(() => CancelTask(ref _reader, taskSource));
+                }
+
+                _reader.PendingTask = taskSource;
+                _reader.PendingBuffer = data;
+                return taskSource.Task;
+            }
+        }
+
+        public Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var data = new ArraySegment<byte>(buffer, offset, count);
+            TaskCompletionSource<int> signaledTask;
+            var task = ReadInternal(data, cancellationToken, out signaledTask);
+            if (signaledTask != null)
+            {
+                signaledTask.SetResult(0);
+            }
+
+            return task;
+        }
+
+        public void CloseReader(Exception e = null)
+        {
+            // Any writes after the reader has closed should cause a failure.
+            if (e == null)
+            {
+                e = new InvalidOperationException("pipe closed");
+            }
+
+            TaskCompletionSource<int> readTask, writeTask;
+
+            lock (_mutex)
+            {
+                readTask = _reader.ReleaseTask();
+                writeTask = _writer.ReleaseTask();
+                if (_reader.Failure == null)
+                {
+                    _reader.Failure = e;
+                }
+            }
+
+            if (writeTask != null)
+            {
+                writeTask.SetException(e);
+            }
+
+            if (readTask != null)
+            {
+                readTask.SetException(new InvalidOperationException("pipe closed"));
+            }
+        }
+
+        public void CloseWriter(Exception e = null)
+        {
+            TaskCompletionSource<int> readTask, writeTask;
+
+            lock (_mutex)
+            {
+                readTask = _reader.ReleaseTask();
+                writeTask = _writer.ReleaseTask();
+                if (_writer.Failure == null)
+                {
+                    _writer.Failure = e;
+                }
+
+                _eof = true;
+            }
+
+            if (readTask != null)
+            {
+                if (e != null)
+                {
+                    readTask.SetException(e);
+                }
+                else
+                {
+                    readTask.SetResult(0);
+                }
+            }
+
+            if (writeTask != null)
+            {
+                writeTask.SetException(new InvalidOperationException("pipe closed"));
+            }
+        }
+
+        private void CancelTask(ref Endpoint endpoint, TaskCompletionSource<int> taskSource)
+        {
+            bool cancel = false;
+            lock (_mutex)
+            {
+                if (taskSource == endpoint.PendingTask)
+                {
+                    endpoint.ReleaseTask();
+                    cancel = true;
+                }
+            }
+
+            if (cancel)
+            {
+                taskSource.SetCanceled();
+            }
+        }
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/PipeReadStream.cs
+++ b/src/Docker.PowerShell/Cmdlets/PipeReadStream.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal class PipeReadStream : Stream
+    {
+        public PipeReadStream(Pipe pipe)
+        {
+            _pipe = pipe;
+        }
+
+        private Pipe _pipe;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length { get { throw new NotImplementedException(); } }
+
+        public override long Position
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var task = _pipe.ReadAsync(buffer, offset, count, CancellationToken.None);
+            task.Wait();
+            return task.Result;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _pipe.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override void Close()
+        {
+            _pipe.CloseReader();
+        }
+
+        public void Close(Exception e)
+        {
+            _pipe.CloseReader(e);
+        }
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/PipeWriteStream.cs
+++ b/src/Docker.PowerShell/Cmdlets/PipeWriteStream.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    internal class PipeWriteStream : Stream
+    {
+        public PipeWriteStream(Pipe pipe)
+        {
+            _pipe = pipe;
+        }
+
+        private Pipe _pipe;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length { get { throw new NotImplementedException(); } }
+
+        public override long Position
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _pipe.WriteAsync(buffer, offset, count, CancellationToken.None).Wait();
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _pipe.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override void Close()
+        {
+            _pipe.CloseWriter();
+        }
+
+        public void Close(Exception e)
+        {
+            _pipe.CloseWriter(e);
+        }
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/StopContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StopContainer.cs
@@ -44,7 +44,7 @@ namespace Docker.PowerShell.Cmdlets
                     if (!await DkrClient.Containers.StopContainerAsync(
                             id,
                             new ContainerStopParameters(),
-                            CancelSignal.Token))
+                            CmdletCancellationToken))
                     {
                         throw new ApplicationFailedException("The container has already stopped.");
                     }

--- a/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
@@ -29,7 +29,7 @@ namespace Docker.PowerShell.Cmdlets
             {
                 var waitResponse = await DkrClient.Containers.WaitContainerAsync(
                     id,
-                    CancelSignal.Token);
+                    CmdletCancellationToken);
 
                 WriteVerbose("Status Code: " + waitResponse.StatusCode.ToString());
                 ContainerOperations.ThrowOnProcessExitCode(waitResponse.StatusCode);

--- a/src/Tar/TarReader.cs
+++ b/src/Tar/TarReader.cs
@@ -195,7 +195,7 @@ namespace Tar
             return entry;
         }
 
-        public async Task<string> ReadGNUEntryData()
+        private async Task<string> ReadGNUEntryData()
         {
             using (var reader = new StreamReader(CurrentFile, TarCommon.UTF8))
             {

--- a/src/Tar/TarReaderExtensions.cs
+++ b/src/Tar/TarReaderExtensions.cs
@@ -5,7 +5,7 @@ namespace Tar
 {
     public static class TarReaderExtensions
     {
-        public static async Task ExtractDirectory(this TarReader reader, string basePath)
+        public static async Task ExtractDirectoryAsync(this TarReader reader, string basePath)
         {
             for (; ;)
             {


### PR DESCRIPTION
Stop using OS pipes to get a tar stream and just implement a simple ring
buffer (kind of like io.Pipe from Go). This improves the error handling of
Build-ContainerImage.