### PR TITLE
Fix trailing path separator in Build

### DIFF
--- a/src/Tar/TarWriterExtensions.cs
+++ b/src/Tar/TarWriterExtensions.cs
@@ -78,7 +78,7 @@ namespace Tar
                     while (enumerator.MoveNext())
                     {
                         var filePath = enumerator.Current;
-                        var fileName = filePath.Substring(path.Length + 1);
+                        var fileName = filePath.Substring(path.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                         var fi = new FileInfo(filePath);
                         var tarPath = Path.Combine(entryBase, fileName);
                         if (progress != null)


### PR DESCRIPTION
Build-ContainerImage fails if it passes a path with a trailing slash in the build source path, so this updates the behavior in Tar to support that case.