### PR TITLE
WIP: Adding dependency on DOCKER_TLS_VERIFY

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/DockerFactory.cs
+++ b/src/Docker.PowerShell/Cmdlets/DockerFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 using Docker.DotNet;
 using Docker.DotNet.X509;
 
@@ -23,8 +24,7 @@ public class DockerFactory
                         System.IO.Path.Combine(CertificateLocation ?? Environment.GetEnvironmentVariable("DOCKER_CERT_PATH"), KeyFileName),
                         certPass));
 
-            //BUGBUG(swernli) - Remove this later in favor of something better.
-            cred.ServerCertificateValidationCallback = (o, c, ch, er) => true;
+            cred.ServerCertificateValidationCallback = (o, c, ch, er) => er == SslPolicyErrors.None;
         }
 
         return new DockerClientConfiguration(new Uri(HostAddress), cred).CreateClient(new Version(ApiVersion));

--- a/src/Docker.PowerShell/Cmdlets/DockerFactory.cs
+++ b/src/Docker.PowerShell/Cmdlets/DockerFactory.cs
@@ -13,15 +13,14 @@ public class DockerFactory
     public static DockerClient CreateClient(string HostAddress, string CertificateLocation)
     {
         HostAddress = HostAddress ?? Environment.GetEnvironmentVariable("DOCKER_HOST") ?? "npipe://./pipe/docker_engine";
-        CertificateLocation = CertificateLocation ?? Environment.GetEnvironmentVariable("DOCKER_CERT_PATH");
-
+        
         CertificateCredentials cred = null;
-        if (!string.IsNullOrEmpty(CertificateLocation))
+        if (!string.IsNullOrEmpty(CertificateLocation) || Environment.GetEnvironmentVariable("DOCKER_TLS_VERIFY") == "1")
         {
             // Try to find a certificate for secure connections.
             cred = new CertificateCredentials(
                     new X509Certificate2(
-                        System.IO.Path.Combine(CertificateLocation, KeyFileName),
+                        System.IO.Path.Combine(CertificateLocation ?? Environment.GetEnvironmentVariable("DOCKER_CERT_PATH"), KeyFileName),
                         certPass));
 
             //BUGBUG(swernli) - Remove this later in favor of something better.


### PR DESCRIPTION
@jstarks 
Adding dependency on DOCKER_TLS_VERIFY environment variable to mimic behavior of docker CLI, ie: DOCKER_CERT_PATH will only be used if the DOCKER_TLS_VERIFY is also set.  Explicitly setting CertificateLocation parameter will still trigger TLS usage for ease of use regardless of environment variables.

Resolves https://github.com/Microsoft/Docker-PowerShell/issues/52