### PR TITLE
Changing JsonError.Code from int to long

### DIFF
--- a/src/Docker.PowerShell/Objects/JsonMessage.cs
+++ b/src/Docker.PowerShell/Objects/JsonMessage.cs
@@ -44,7 +44,7 @@ namespace Docker.PowerShell.Objects
     internal class JsonError
     {
         [JsonProperty(PropertyName = "code")]
-        public int Code { get; set; }
+        public long Code { get; set; }
 
         [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }


### PR DESCRIPTION
@jstarks @jterry75 

Golang integer types are dynamically compiled as long when built for 64-bit, so error codes returned need to be interpreted as long.