### PR TITLE
Adding cmdlet for Tagging images

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/RemoveContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/RemoveContainerImage.cs
@@ -11,7 +11,7 @@ namespace Docker.PowerShell.Cmdlets
         #region Parameters
 
         /// <summary>
-        /// Whether or not to force the removal of the container.
+        /// Whether or not to force the removal of the image.
         /// </summary>
         [Parameter]
         public SwitchParameter Force { get; set; }

--- a/src/Docker.PowerShell/Cmdlets/SetContainerImageTag.cs
+++ b/src/Docker.PowerShell/Cmdlets/SetContainerImageTag.cs
@@ -1,0 +1,52 @@
+using System.Management.Automation;
+using Docker.DotNet.Models;
+using System.Threading.Tasks;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsCommon.Set, "ContainerImageTag",
+            DefaultParameterSetName = CommonParameterSetNames.Default)]
+    [Alias("Tag-ContainerImage")]
+    public class SetContainerImageTag : ImageOperationCmdlet
+    {
+        #region Parameters
+
+        [Parameter]
+        public SwitchParameter Force { get; set; }
+        
+        [Parameter(Position = 1,
+                   Mandatory = true)]
+        [ValidateNotNullOrEmpty]
+        public string Repository { get; set; }
+
+        [Parameter(Position = 2)]
+        [ValidateNotNullOrEmpty]
+        public string Tag { get; set; }
+
+        #endregion
+
+        #region Overrides
+
+        protected override async Task ProcessRecordAsync()
+        {
+            foreach (var id in ParameterResolvers.GetImageIds(Image, Id))
+            {
+                var tagParams = new ImageTagParameters(){ RepositoryName = Repository };
+                                
+                if (!string.IsNullOrEmpty(Tag))
+                {
+                    tagParams.Tag = Tag;
+                }
+                
+                if (Force)
+                {
+                    tagParams.Force = true;
+                }
+                
+                await DkrClient.Images.TagImageAsync(id, tagParams);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -49,6 +49,7 @@ CmdletsToExport = @(
     'Remove-Container',
     'Remove-ContainerImage',
     'Invoke-ContainerImage',
+    'Set-ContainerImageTag',
     'Start-Container',
     'Stop-Container',
     'Wait-Container'
@@ -59,7 +60,8 @@ CmdletsToExport = @(
 AliasesToExport = @(
     'Commit-Container',
     'Build-ContainerImage',
-    'Run-ContainerImage'
+    'Run-ContainerImage',
+    'Tag-ContainerImage'
 )
 
 # HelpInfo


### PR DESCRIPTION
Added a Set-ContainerImageTag cmdlet (aliased as Tag-ContainerImage).  Also updated incorrect comment on remove-containerimage.
This addresses https://github.com/Microsoft/Docker-PowerShell/issues/65.