### PR TITLE
Adding -Id and -Name params to Get-Container

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
+++ b/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
@@ -13,6 +13,7 @@ namespace Docker.PowerShell.Cmdlets
     {
         public const string Default = "Default";
         public const string ContainerObject = "ContainerObject";
+        public const string ContainerName = "ContainerName";
         public const string ImageObject = "ImageObject";
         public const string ConfigObject = "ConfigObject";
     }

--- a/src/Docker.PowerShell/Cmdlets/GetContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/GetContainer.cs
@@ -1,25 +1,56 @@
 ﻿using System.Management.Automation;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using Docker.PowerShell.Objects;
 
 namespace Docker.PowerShell.Cmdlets
 {
     [Cmdlet(VerbsCommon.Get, "Container",
-            DefaultParameterSetName = CommonParameterSetNames.Default)]
+            DefaultParameterSetName = CommonParameterSetNames.ContainerName)]
     [OutputType(typeof(ContainerListResponse))]
     public class GetContainer : DkrCmdlet
     {
+        [Parameter(ParameterSetName = CommonParameterSetNames.Default,
+            ValueFromPipeline = true,
+                   Position = 0)]
+        [ValidateNotNullOrEmpty]
+        [ArgumentCompleter(typeof(ContainerArgumentCompleter))]
+        public string[] Id { get; set; }
+
+        [Parameter(ParameterSetName = CommonParameterSetNames.ContainerName,
+            ValueFromPipeline = true,
+                   Position = 0)]
+        [ValidateNotNullOrEmpty]
+        [ArgumentCompleter(typeof(ContainerArgumentCompleter))]
+        public string[] Name { get; set; }
 
         #region Overrides
         /// <summary>
         /// Outputs container objects for each container matching the provided parameters.
         /// </summary>
         protected override async Task ProcessRecordAsync()
-        {
-            foreach (var c in await DkrClient.Containers.ListContainersAsync(
-                new ContainersListParameters() { All = true }))
+        {            
+            if (Id != null)
             {
-                WriteObject(c);
+                foreach (var id in Id)
+                {
+                    WriteObject(await ContainerOperations.GetContainersById(id, DkrClient));    
+                }
+            }
+            else if (Name != null)
+            {
+                foreach (var name in Name)
+                {
+                    WriteObject(await ContainerOperations.GetContainersByName(name, DkrClient));
+                }
+            }
+            else
+            {
+                foreach (var c in await DkrClient.Containers.ListContainersAsync(
+                    new ContainersListParameters() { All = true }))
+                {
+                    WriteObject(c);
+                }
             }
         }
 

--- a/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
@@ -3,6 +3,7 @@ using System.Management.Automation;
 using Docker.PowerShell.Objects;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -77,7 +78,7 @@ namespace Docker.PowerShell.Cmdlets
                     }
                     else if (PassThru.ToBool())
                     {
-                        WriteObject(await ContainerOperations.GetContainerById(createResult.ID, DkrClient));
+                        WriteObject((await ContainerOperations.GetContainersById(createResult.ID, DkrClient)).Single());
                     }
                 }
             }

--- a/src/Docker.PowerShell/Cmdlets/NewContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/NewContainer.cs
@@ -3,6 +3,7 @@ using System.Management.Automation;
 using Docker.PowerShell.Objects;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -38,7 +39,7 @@ namespace Docker.PowerShell.Cmdlets
 
                 if (!String.IsNullOrEmpty(createResult.ID))
                 {
-                    WriteObject(await ContainerOperations.GetContainerById(createResult.ID, DkrClient));
+                    WriteObject((await ContainerOperations.GetContainersById(createResult.ID, DkrClient)).Single());
                 }
             }
         }

--- a/src/Docker.PowerShell/Cmdlets/StartContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StartContainer.cs
@@ -35,7 +35,7 @@ namespace Docker.PowerShell.Cmdlets
 
                 if (PassThru.ToBool())
                 {
-                    WriteObject(await ContainerOperations.GetContainerById(id, DkrClient));
+                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
                 }
             }
         }

--- a/src/Docker.PowerShell/Cmdlets/StopContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StopContainer.cs
@@ -52,7 +52,7 @@ namespace Docker.PowerShell.Cmdlets
 
                 if (PassThru.ToBool())
                 {
-                    WriteObject(await ContainerOperations.GetContainerById(id, DkrClient));
+                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
                 }
             }
         }

--- a/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
@@ -36,7 +36,7 @@ namespace Docker.PowerShell.Cmdlets
 
                 if (PassThru.ToBool())
                 {
-                    WriteObject(await ContainerOperations.GetContainerById(id, DkrClient));
+                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
                 }
             }
         }


### PR DESCRIPTION
As part of this change, updated to the most recent generated Docker.DotNet api (see https://github.com/ahmetalpbalkan/Docker.DotNet/pull/81) to enable filtering on listing containers.
Also included update to the tab-completion logic in ContainerArgumentCompleter to make it more efficient.
Also updated callers of GetContainerById to more specifically filter based on requested items.

This resolves https://github.com/Microsoft/Docker-PowerShell/issues/75.