### PR TITLE
Fixing pipeline error handling

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
+++ b/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
@@ -3,6 +3,7 @@ using Docker.DotNet;
 using System.Threading;
 using System.Threading.Tasks;
 using Docker.PowerShell.Support;
+using System;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -75,7 +76,23 @@ namespace Docker.PowerShell.Cmdlets
 
         protected sealed override void ProcessRecord()
         {
-            AsyncPump.Run(ProcessRecordAsync);
+            try
+            {
+                AsyncPump.Run(ProcessRecordAsync);                
+            }
+            catch (Exception e)
+            {
+                if (e is PipelineStoppedException)
+                {
+                    // PipelineStoppedException shouldn't be ignored.
+                    throw e;
+                }
+                else
+                {
+                    // Handle the exception and continue to process other objects.
+                    WriteError(new ErrorRecord(e, "Docker Client Exception", ErrorCategory.NotSpecified, null));
+                }
+            }
         }
 
         protected abstract Task ProcessRecordAsync();


### PR DESCRIPTION
@jterry75 
Rather than throw an exception, which can bail out of the PowerShell pipeline, we catch the exception and write it back as an error record.  We can iterate on cleaner error handling from here.