### PR TITLE
Removing Name parameter from Get-Container

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/ContainerArgumentCompleter.cs
+++ b/src/Docker.PowerShell/Cmdlets/ContainerArgumentCompleter.cs
@@ -36,12 +36,7 @@ public class ContainerArgumentCompleter : IArgumentCompleter
                 // If the user has already typed part of the name, then include IDs that start
                 // with that portion. Otherwise, just let the user tab through the names.
                 
-                // Special handling for Get-Container, where Id an Name are separate parameters.
-                if (commandName == "Get-Container" && parameterName == "Id")
-                {
-                    return new List<string> {container.ID};
-                }
-                else if (wordToComplete == "" || parameterName == "Name")
+                if (wordToComplete == "")
                 {
                     return container.Names;
                 }

--- a/src/Docker.PowerShell/Cmdlets/CopyContainerFile.cs
+++ b/src/Docker.PowerShell/Cmdlets/CopyContainerFile.cs
@@ -30,7 +30,7 @@ namespace Docker.PowerShell.Cmdlets
                 Id = Container.ID;
             }
 
-            if (ToContainer.ToBool())
+            if (ToContainer)
             {
                 var hostPaths = Path.SelectMany(path =>
                 {

--- a/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
+++ b/src/Docker.PowerShell/Cmdlets/DkrCmdlet.cs
@@ -14,11 +14,11 @@ namespace Docker.PowerShell.Cmdlets
     {
         public const string Default = "Default";
         public const string ContainerObject = "ContainerObject";
-        public const string ContainerName = "ContainerName";
         public const string ImageObject = "ImageObject";
         public const string ConfigObject = "ConfigObject";
         public const string NetworkName = "NetworkName";
         public const string NetworkObject = "NetworkObject";
+        public const string AllImages = "AllImages";
     }
 
     public abstract class DkrCmdlet : PSCmdlet

--- a/src/Docker.PowerShell/Cmdlets/GetContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/GetContainer.cs
@@ -6,7 +6,7 @@ using Docker.PowerShell.Objects;
 namespace Docker.PowerShell.Cmdlets
 {
     [Cmdlet(VerbsCommon.Get, "Container",
-            DefaultParameterSetName = CommonParameterSetNames.ContainerName)]
+            DefaultParameterSetName = CommonParameterSetNames.Default)]
     [OutputType(typeof(ContainerListResponse))]
     public class GetContainer : DkrCmdlet
     {
@@ -15,33 +15,20 @@ namespace Docker.PowerShell.Cmdlets
                    Position = 0)]
         [ValidateNotNullOrEmpty]
         [ArgumentCompleter(typeof(ContainerArgumentCompleter))]
+        [Alias("Name")]
         public string[] Id { get; set; }
-
-        [Parameter(ParameterSetName = CommonParameterSetNames.ContainerName,
-            ValueFromPipeline = true,
-                   Position = 0)]
-        [ValidateNotNullOrEmpty]
-        [ArgumentCompleter(typeof(ContainerArgumentCompleter))]
-        public string[] Name { get; set; }
 
         #region Overrides
         /// <summary>
         /// Outputs container objects for each container matching the provided parameters.
         /// </summary>
         protected override async Task ProcessRecordAsync()
-        {            
+        {
             if (Id != null)
             {
                 foreach (var id in Id)
                 {
-                    WriteObject(await ContainerOperations.GetContainersById(id, DkrClient));    
-                }
-            }
-            else if (Name != null)
-            {
-                foreach (var name in Name)
-                {
-                    WriteObject(await ContainerOperations.GetContainersByName(name, DkrClient));
+                    WriteObject(await ContainerOperations.GetContainersByIdOrName(id, DkrClient));
                 }
             }
             else

--- a/src/Docker.PowerShell/Cmdlets/ImageArgumentCompleter.cs
+++ b/src/Docker.PowerShell/Cmdlets/ImageArgumentCompleter.cs
@@ -18,7 +18,7 @@ public class ImageArgumentCompleter : IArgumentCompleter
     {
         var client = DockerFactory.CreateClient(fakeBoundParameters);
 
-        var task = client.Images.ListImagesAsync(new ImagesListParameters());
+        var task = client.Images.ListImagesAsync(new ImagesListParameters(){ All = true });
         task.Wait();
 
         return task.Result.SelectMany(image =>

--- a/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
@@ -71,12 +71,12 @@ namespace Docker.PowerShell.Cmdlets
                     WriteVerbose("Status Code: " + waitResponse.StatusCode.ToString());
                     ContainerOperations.ThrowOnProcessExitCode(waitResponse.StatusCode);
 
-                    if (RemoveAutomatically.ToBool())
+                    if (RemoveAutomatically)
                     {
                         await DkrClient.Containers.RemoveContainerAsync(createResult.ID,
                             new ContainerRemoveParameters());
                     }
-                    else if (PassThru.ToBool())
+                    else if (PassThru)
                     {
                         WriteObject((await ContainerOperations.GetContainersById(createResult.ID, DkrClient)).Single());
                     }

--- a/src/Docker.PowerShell/Cmdlets/NewContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/NewContainerImage.cs
@@ -62,9 +62,9 @@ namespace Docker.PowerShell.Cmdlets
             {
                 var parameters = new ImageBuildParameters
                 {
-                    NoCache = SkipCache.ToBool(),
-                    ForceRemove = ForceRemoveIntermediateContainers.ToBool(),
-                    Remove = !PreserveIntermediateContainers.ToBool(),
+                    NoCache = SkipCache,
+                    ForceRemove = ForceRemoveIntermediateContainers,
+                    Remove = !PreserveIntermediateContainers,
                 };
 
                 string repoTag = null;

--- a/src/Docker.PowerShell/Cmdlets/StartContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StartContainer.cs
@@ -2,6 +2,7 @@
 using Docker.PowerShell.Objects;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -33,9 +34,9 @@ namespace Docker.PowerShell.Cmdlets
                     throw new ApplicationFailedException("The container has already started.");
                 }
 
-                if (PassThru.ToBool())
+                if (PassThru)
                 {
-                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
+                    WriteObject((await ContainerOperations.GetContainersByIdOrName(id, DkrClient)).Single());
                 }
             }
         }

--- a/src/Docker.PowerShell/Cmdlets/StopContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StopContainer.cs
@@ -2,6 +2,7 @@
 using Docker.PowerShell.Objects;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -33,7 +34,7 @@ namespace Docker.PowerShell.Cmdlets
         {
             foreach (var id in ParameterResolvers.GetContainerIds(Container, Id))
             {
-                if (Force.ToBool())
+                if (Force)
                 {
                     await DkrClient.Containers.KillContainerAsync(
                         id,
@@ -50,9 +51,9 @@ namespace Docker.PowerShell.Cmdlets
                     }
                 }
 
-                if (PassThru.ToBool())
+                if (PassThru)
                 {
-                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
+                    WriteObject((await ContainerOperations.GetContainersByIdOrName(id, DkrClient)).Single());
                 }
             }
         }

--- a/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/WaitContainer.cs
@@ -2,6 +2,7 @@
 using Docker.PowerShell.Objects;
 using Docker.DotNet.Models;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Docker.PowerShell.Cmdlets
 {
@@ -34,9 +35,9 @@ namespace Docker.PowerShell.Cmdlets
                 WriteVerbose("Status Code: " + waitResponse.StatusCode.ToString());
                 ContainerOperations.ThrowOnProcessExitCode(waitResponse.StatusCode);
 
-                if (PassThru.ToBool())
+                if (PassThru)
                 {
-                    WriteObject(await ContainerOperations.GetContainerByIdOrName(id, DkrClient));
+                    WriteObject((await ContainerOperations.GetContainersByIdOrName(id, DkrClient)).Single());
                 }
             }
         }

--- a/src/Docker.PowerShell/Objects/ContainerOperations.cs
+++ b/src/Docker.PowerShell/Objects/ContainerOperations.cs
@@ -61,9 +61,9 @@ namespace Docker.PowerShell.Objects
                 hostConfiguration.Isolation = cmdlet.Isolation.ToString();
             }
 
-            configuration.Tty = cmdlet.Terminal.ToBool();
-            configuration.OpenStdin = cmdlet.Input.ToBool();
-            configuration.AttachStdin = cmdlet.Input.ToBool();
+            configuration.Tty = cmdlet.Terminal;
+            configuration.OpenStdin = cmdlet.Input;
+            configuration.AttachStdin = cmdlet.Input;
             configuration.AttachStdout = true;
             configuration.AttachStderr = true;
 
@@ -113,9 +113,9 @@ namespace Docker.PowerShell.Objects
         /// <param name="id">The container identifier to retrieve.</param>
         /// <param name="dkrClient">The client to request the container from.</param>
         /// <returns>The single container object matching the id.</returns>
-        internal static async Task<ContainerListResponse> GetContainerByIdOrName(string id, DotNet.DockerClient dkrClient)
+        internal static async Task<IList<ContainerListResponse>> GetContainersByIdOrName(string id, DotNet.DockerClient dkrClient)
         {
-            return (await GetContainersByName(id, dkrClient)).Where(c => c.Names.Contains($"/{id}")).Concat(await GetContainersById(id, dkrClient)).Single();
+            return (await GetContainersByName(id, dkrClient)).Where(c => c.Names.Contains($"/{id}")).Concat(await GetContainersById(id, dkrClient)).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
@jstarks @jterry75 
Removing the name parameter from Get-Container in favor of general purpose ID parameter to match other cmdlets.  Some additional clean-up of unnecessary "ToBool" usage.

Addresses #95.