### PR TITLE
Fixing VSCode build task to use full paths

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
 		{
 			"taskName": "build",
 			"suppressTaskName": true,
-			"args" : ["dotnet", "publish", ".\\src\\Docker.PowerShell", "-o", ".\\src\\Docker.PowerShell\\bin\\Module\\Docker", "-r", "win"],
+			"args" : ["dotnet", "publish", "${cwd}\\src\\Docker.PowerShell", "-o", "${cwd}\\src\\Docker.PowerShell\\bin\\Module\\Docker", "-r", "win"],
 			"showOutput": "always",
 			"isBuildCommand": true,
 			"problemMatcher": "$msCompile"


### PR DESCRIPTION
@jterry75 
This avoids a bug in dotnet publish (tracked here https://github.com/dotnet/cli/issues/3833) where relative paths cause dotnet cli to skip publishOptions include files.