### PR TITLE
Adding automatic help content verification

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,12 +32,20 @@ build_script:
     $manifest = "src\Docker.PowerShell\Docker.psd1"
     (Get-Content $manifest -Raw) -replace "ModuleVersion.+","ModuleVersion = '$psversion'" | Out-File $manifest
 - ps: dotnet restore
-- ps: dotnet publish -r win -o bin -c Release src/Docker.PowerShell
-- ps: New-ExternalHelp -Path src/Docker.PowerShell/Help -OutputPath bin
+- ps: dotnet publish -r win -o $pwd\bin -c Release $pwd\src\Docker.PowerShell
+- ps: New-ExternalHelp -Path src\Docker.PowerShell\Help -OutputPath bin
 - ps: nuget pack src/Docker.PowerShell/Docker.nuspec -BasePath bin -OutputDirectory bin -Symbols -Version $psversion
 test_script:
 - ps: Register-PSRepository -Name test -SourceLocation $pwd\bin
 - ps: Install-Module -Name Docker -Repository test -Force
 - ps: Import-Module Docker
+- ps: git checkout -- src/Docker.PowerShell/Docker.psd1
+- ps: git checkout -- src/Docker.PowerShell/project.json
+- ps: New-MarkdownHelp -Module Docker -OutputFolder src\Docker.PowerShell\Help -ErrorAction SilentlyContinue
+- ps: Update-MarkdownHelp -Path src\Docker.PowerShell\Help
+- ps: |
+    if ((git status -s)){
+      throw "Help files do not match updated cmdlets. Please update the help markdown to correspond to the latest changes." 
+    }
 artifacts:
 - path: bin/*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ install:
 nuget:
   disable_publish_on_pr: true
 build_script:
+- ps: $psversiontable
+- ps: dotnet --version
+- ps: get-packageprovider nuget
+- ps: get-module -name platyPS
 - ps: |
     $env:PATH = "c:\program files\dotnet;$env:PATH"
 
@@ -44,6 +48,8 @@ test_script:
 - ps: New-MarkdownHelp -Module Docker -OutputFolder src\Docker.PowerShell\Help -ErrorAction SilentlyContinue
 - ps: Update-MarkdownHelp -Path src\Docker.PowerShell\Help
 - ps: |
+    git status -s
+    git diff
     if ((git status -s)){
       throw "Help files do not match updated cmdlets. Please update the help markdown to correspond to the latest changes." 
     }


### PR DESCRIPTION
@jstarks @jterry75 @aoatkinson 
This addition to appveyor will automatically run help generation steps and then compare the resulting files to the user submitted changes.  If any differences are detected, it fails a test case to inform that the PR is missing help content updates.