### PR TITLE
Adding automatic help content verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ made to the structure or behavior of the cmdlets.  Follow the instructions on th
 platyPS github readme to get the module installed, and then after imported the
 Docker module with your changes compiled in, run:
 
-    > New-MarkdownHelp -Module Docker -OutputFolder .\src\Docker.Powershell\Help
+    > New-MarkdownHelp -Module Docker -OutputFolder .\src\Docker.Powershell\Help -ErrorAction SilentlyContinue
 
     > Update-MarkdownHelp -Path .\src\Docker.PowerShell\Help
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,16 @@ init:
 - ps: (new-object net.webclient).DownloadFile('https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-dev-win-x64.latest.exe', "c:/dotnet-install.exe")
 - ps: Start-Process c:\dotnet-install.exe -ArgumentList "/install","/quiet" -Wait
 - ps: Install-PackageProvider NuGet -Force
-- ps: Install-Module PlatyPS -Force
+- ps: Install-Module platyPS -Force
 install:
 - cmd: git submodule update --init --recursive
 nuget:
   disable_publish_on_pr: true
 build_script:
+- ps: $psversiontable
+- ps: dotnet --version
+- ps: get-packageprovider nuget
+- ps: ipmo platyPS ; get-module -name platyPS
 - ps: |
     $env:PATH = "c:\program files\dotnet;$env:PATH"
 
@@ -32,12 +36,24 @@ build_script:
     $manifest = "src\Docker.PowerShell\Docker.psd1"
     (Get-Content $manifest -Raw) -replace "ModuleVersion.+","ModuleVersion = '$psversion'" | Out-File $manifest
 - ps: dotnet restore
-- ps: dotnet publish -r win -o bin -c Release src/Docker.PowerShell
-- ps: New-ExternalHelp -Path src/Docker.PowerShell/Help -OutputPath bin
+- ps: dotnet publish -r win -o $pwd\bin -c Release $pwd\src\Docker.PowerShell
+- ps: New-ExternalHelp -Path src\Docker.PowerShell\Help -OutputPath bin
 - ps: nuget pack src/Docker.PowerShell/Docker.nuspec -BasePath bin -OutputDirectory bin -Symbols -Version $psversion
 test_script:
 - ps: Register-PSRepository -Name test -SourceLocation $pwd\bin
 - ps: Install-Module -Name Docker -Repository test -Force
 - ps: Import-Module Docker
+- ps: git checkout -- src/Docker.PowerShell/Docker.psd1
+- ps: git checkout -- src/Docker.PowerShell/project.json
+- ps: git config core.autocrlf true
+- ps: New-MarkdownHelp -Module Docker -OutputFolder src\Docker.PowerShell\Help -ErrorAction SilentlyContinue
+- ps: Update-MarkdownHelp -Path src\Docker.PowerShell\Help
+- ps: |
+    git add src\Docker.PowerShell\Help\.
+    git status -s
+    git diff
+    if ((git status -s)){
+      throw "Help files do not match updated cmdlets. Please update the help markdown to correspond to the latest changes." 
+    }
 artifacts:
 - path: bin/*.nupkg

--- a/src/Docker.PowerShell/Help/ConvertTo-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/ConvertTo-ContainerImage.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # ConvertTo-ContainerImage

--- a/src/Docker.PowerShell/Help/Copy-ContainerFile.md
+++ b/src/Docker.PowerShell/Help/Copy-ContainerFile.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Copy-ContainerFile

--- a/src/Docker.PowerShell/Help/Enter-Container.md
+++ b/src/Docker.PowerShell/Help/Enter-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Enter-Container

--- a/src/Docker.PowerShell/Help/Get-Container.md
+++ b/src/Docker.PowerShell/Help/Get-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Get-Container

--- a/src/Docker.PowerShell/Help/Get-ContainerDetail.md
+++ b/src/Docker.PowerShell/Help/Get-ContainerDetail.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Get-ContainerDetail

--- a/src/Docker.PowerShell/Help/Get-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Get-ContainerImage.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Get-ContainerImage

--- a/src/Docker.PowerShell/Help/Get-ContainerNet.md
+++ b/src/Docker.PowerShell/Help/Get-ContainerNet.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Get-ContainerNet

--- a/src/Docker.PowerShell/Help/Get-ContainerNetDetail.md
+++ b/src/Docker.PowerShell/Help/Get-ContainerNetDetail.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Get-ContainerNetDetail

--- a/src/Docker.PowerShell/Help/Invoke-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Invoke-ContainerImage.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Invoke-ContainerImage

--- a/src/Docker.PowerShell/Help/New-Container.md
+++ b/src/Docker.PowerShell/Help/New-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # New-Container

--- a/src/Docker.PowerShell/Help/New-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/New-ContainerImage.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # New-ContainerImage

--- a/src/Docker.PowerShell/Help/New-ContainerNet.md
+++ b/src/Docker.PowerShell/Help/New-ContainerNet.md
@@ -1,7 +1,7 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
 online version: 
+schema: 2.0.0
 ---
 
 # New-ContainerNet

--- a/src/Docker.PowerShell/Help/Remove-Container.md
+++ b/src/Docker.PowerShell/Help/Remove-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Remove-Container

--- a/src/Docker.PowerShell/Help/Remove-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Remove-ContainerImage.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Remove-ContainerImage

--- a/src/Docker.PowerShell/Help/Remove-ContainerNet.md
+++ b/src/Docker.PowerShell/Help/Remove-ContainerNet.md
@@ -1,7 +1,7 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
 online version: 
+schema: 2.0.0
 ---
 
 # Remove-ContainerNet

--- a/src/Docker.PowerShell/Help/Set-ContainerImageTag.md
+++ b/src/Docker.PowerShell/Help/Set-ContainerImageTag.md
@@ -1,7 +1,7 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
 online version: 
+schema: 2.0.0
 ---
 
 # Set-ContainerImageTag

--- a/src/Docker.PowerShell/Help/Start-Container.md
+++ b/src/Docker.PowerShell/Help/Start-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Start-Container

--- a/src/Docker.PowerShell/Help/Stop-Container.md
+++ b/src/Docker.PowerShell/Help/Stop-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Stop-Container

--- a/src/Docker.PowerShell/Help/Wait-Container.md
+++ b/src/Docker.PowerShell/Help/Wait-Container.md
@@ -1,6 +1,6 @@
 ---
-schema: 2.0.0
 external help file: Docker.PowerShell.dll-Help.xml
+schema: 2.0.0
 ---
 
 # Wait-Container


### PR DESCRIPTION
@jterry75 @aoatkinson 
This addition to appveyor will automatically run help generation steps and then compare the resulting files to the user submitted changes.  If any differences are detected, it fails a test case to inform that the PR is missing help content updates.
Note: this PR includes the updated help content that matches latest version of platyPS.