### PR TITLE
Renaming Enter-Container to Enter-ContainerSession

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/EnterContainerSession.cs
+++ b/src/Docker.PowerShell/Cmdlets/EnterContainerSession.cs
@@ -6,9 +6,9 @@ using Docker.PowerShell.Support;
 
 namespace Docker.PowerShell.Cmdlets
 {
-    [Cmdlet(VerbsCommon.Enter, "Container",
+    [Cmdlet(VerbsCommon.Enter, "ContainerSession",
             DefaultParameterSetName = CommonParameterSetNames.Default)]
-    public class EnterContainer : SingleContainerOperationCmdlet
+    public class EnterContainerSession : SingleContainerOperationCmdlet
     {
         protected override async Task ProcessRecordAsync()
         {

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -38,7 +38,7 @@ FormatsToProcess = 'Docker.Format.ps1xml'
 CmdletsToExport = @(
     'ConvertTo-ContainerImage',
     'Copy-ContainerFile',
-    'Enter-Container',
+    'Enter-ContainerSession',
     'Get-Container',
     'Get-ContainerDetail',
     'Get-ContainerImage',

--- a/src/Docker.PowerShell/Help/Enter-ContainerSession.md
+++ b/src/Docker.PowerShell/Help/Enter-ContainerSession.md
@@ -3,21 +3,23 @@ external help file: Docker.PowerShell.dll-Help.xml
 schema: 2.0.0
 ---
 
-# Enter-Container
+# Enter-ContainerSession
 ## SYNOPSIS
-Enter-Container \[-Id\] \<string\> \[-HostAddress \<string\>\] \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
+Enter-ContainerSession \[-Id\] \<string\> \[-HostAddress \<string\>\] \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
 
-Enter-Container \[-Container\] \<ContainerListResponse\> \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
+Enter-ContainerSession \[-Container\] \<ContainerListResponse\> \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
 ## SYNTAX
 
 ### Default (Default)
 ```
-Enter-Container [-Id] <String> [-HostAddress <String>] [-CertificateLocation <String>] [<CommonParameters>]
+Enter-ContainerSession [-Id] <String> [-HostAddress <String>] [-CertificateLocation <String>]
+ [<CommonParameters>]
 ```
 
 ### ContainerObject
 ```
-Enter-Container [-Container] <ContainerListResponse> [-CertificateLocation <String>] [<CommonParameters>]
+Enter-ContainerSession [-Container] <ContainerListResponse> [-CertificateLocation <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,7 +28,7 @@ Connects to interactive session in the specified container.
 
 ### Example 1
 ```
-PS C:\> {{ Enter-Container $myContainer}}
+PS C:\> {{ Enter-ContainerSession $myContainer}}
 ```
 
 Connects to $myContainer


### PR DESCRIPTION
@jstarks 
Renaming cmdlet for consistency with other powershell usages. Fixes #90.