### PR TITLE
Adding Exec functionality

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/EnterContainerSession.cs
+++ b/src/Docker.PowerShell/Cmdlets/EnterContainerSession.cs
@@ -8,6 +8,7 @@ namespace Docker.PowerShell.Cmdlets
 {
     [Cmdlet(VerbsCommon.Enter, "ContainerSession",
             DefaultParameterSetName = CommonParameterSetNames.Default)]
+    [Alias("Attach-Container")]
     public class EnterContainerSession : SingleContainerOperationCmdlet
     {
         protected override async Task ProcessRecordAsync()
@@ -29,7 +30,7 @@ namespace Docker.PowerShell.Cmdlets
 
             using (var stream = await DkrClient.Containers.AttachContainerAsync(inspect.ID, inspect.Config.Tty, parameters, CmdletCancellationToken))
             {
-                await stream.CopyToConsoleAsync(inspect.Config, CmdletCancellationToken);
+                await stream.CopyToConsoleAsync(inspect.Config.Tty, inspect.Config.OpenStdin, CmdletCancellationToken);
             }
         }
     }

--- a/src/Docker.PowerShell/Cmdlets/StartContainerProcess.cs
+++ b/src/Docker.PowerShell/Cmdlets/StartContainerProcess.cs
@@ -1,0 +1,96 @@
+using System.Management.Automation;
+using Docker.DotNet.Models;
+using System.Threading.Tasks;
+using Docker.PowerShell.Support;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsLifecycle.Start, "ContainerProcess",
+            DefaultParameterSetName = CommonParameterSetNames.Default)]
+    [OutputType(typeof(ContainerListResponse))]
+    [Alias("Exec-Container")]
+    public class StartContainerProcess : SingleContainerOperationCmdlet
+    {
+        #region Parameters
+
+        /// <summary>
+        /// The command to use by default when starting new container.
+        /// </summary>
+        [Parameter(ParameterSetName = CommonParameterSetNames.Default,
+            ValueFromRemainingArguments = true,
+            Position = 1)]
+        [Parameter(ParameterSetName = CommonParameterSetNames.ContainerObject,
+            ValueFromRemainingArguments = true,
+            Position = 1)]
+        [ValidateNotNullOrEmpty]
+        public string[] Command { get; set; }
+
+        /// <summary>
+        /// Whether or not to start the process in detached mode.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Detached { get; set; }
+
+        /// <summary>
+        /// Whether or not to use stdin of the started process.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Input { get; set; }
+
+        /// <summary>
+        /// Whether or not to use terminal emulation.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Terminal { get; set; }
+
+        /// <summary>
+        /// Whether or not to start the process in privileged mode.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter Privileged { get; set; }
+
+        /// <summary>
+        /// The user context under which the process should be started.
+        /// </summary>
+        [Parameter]
+        public string User { get; set; }
+
+        #endregion
+
+        #region Overrides
+
+        protected override async Task ProcessRecordAsync()
+        {
+            var id = Id ?? Container.ID;
+
+            var execConfig = new ExecConfig()
+            {
+                Cmd = Command,
+                Privileged = Privileged,
+                User = User,
+                AttachStdin = !Detached && Input,
+                AttachStdout = !Detached,
+                AttachStderr = !Detached,
+                Detach = Detached,
+                Tty = Terminal,
+            };
+
+            var procCreateResponse = await DkrClient.Containers.ExecCreateContainerAsync(id, new ContainerExecCreateParameters(execConfig));
+
+            if (Detached)
+            {
+                await DkrClient.Containers.StartContainerExecAsync(procCreateResponse.ID, CmdletCancellationToken);
+                WriteObject(await DkrClient.Containers.InspectContainerExecAsync(procCreateResponse.ID, CmdletCancellationToken));
+            }
+            else
+            {
+                using (var stream = await DkrClient.Containers.StartWithConfigContainerExecAsync(procCreateResponse.ID, execConfig, CmdletCancellationToken))
+                {
+                    await stream.CopyToConsoleAsync(Terminal, Input, CmdletCancellationToken);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -53,6 +53,7 @@ CmdletsToExport = @(
     'Invoke-ContainerImage',
     'Set-ContainerImageTag',
     'Start-Container',
+    'Start-ContainerProcess',
     'Stop-Container',
     'Wait-Container'
 )
@@ -60,8 +61,10 @@ CmdletsToExport = @(
 
 # Aliases to export from this module
 AliasesToExport = @(
-    'Commit-Container',
+    'Attach-Container',
     'Build-ContainerImage',
+    'Commit-Container',
+    'Exec-Container',
     'Run-ContainerImage',
     'Tag-ContainerImage'
 )

--- a/src/Docker.PowerShell/Help/Start-ContainerProcess.md
+++ b/src/Docker.PowerShell/Help/Start-ContainerProcess.md
@@ -1,0 +1,202 @@
+---
+external help file: Docker.PowerShell.dll-Help.xml
+online version: https://github.com/Microsoft/Docker-PowerShell/tree/master/src/Docker.PowerShell/en-us/
+schema: 2.0.0
+---
+
+# Start-ContainerProcess
+## SYNOPSIS
+Start-ContainerProcess \[-Id\] \<string\[\]\> \[\[-Command\] \<string\[\]\>\] \[-Detached\] \[-TTY\] \[-Privileged\] \[-User \<string\[\]\>\]\[-HostAddress \<string\>\] \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
+
+Start-ContainerProcess \[-Container\] \<ContainerListResponse\[\]\> \[\[-Command\] \<string\[\]\>\] \[-Detached\] \[-TTY\] \[-Privileged\] \[-User \<string\[\]\>\]\[-HostAddress \<string\>\] \[-CertificateLocation \<string\>\] \[\<CommonParameters\>\]
+## SYNTAX
+
+### Default (Default)
+```
+Start-ContainerProcess [[-Command] <String[]>] [-Detached] [-Input] [-Terminal] [-Privileged] [-User <String>]
+ [-Id] <String> [-HostAddress <String>] [-CertificateLocation <String>] [<CommonParameters>]
+```
+
+### ContainerObject
+```
+Start-ContainerProcess [[-Command] <String[]>] [-Detached] [-Input] [-Terminal] [-Privileged] [-User <String>]
+ [-Container] <ContainerListResponse> [-CertificateLocation <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Starts a new process with the given command in the specified container.
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+## PARAMETERS
+
+### -CertificateLocation
+The location of the X509 certificate file named "key.pfx" that will be used for authentication with the server.  (Note that certificate authorization work is still in progress and this is likely to change).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Command
+The command to be run as a new process in the container. 
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 1
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Container
+The container in which the process will be started.
+
+```yaml
+Type: ContainerListResponse
+Parameter Sets: ContainerObject
+Aliases: 
+
+Required: True
+Position: 0
+Default value: 
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Detached
+If specified, just the container process object will be returned and the process will run asynchronously.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAddress
+The address of the docker daemon to connect to.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+The identifier for the container in which the process will be started.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases: Name
+
+Required: True
+Position: 0
+Default value: 
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Privileged
+If specified, the process will be started in privileged mode.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -User
+A custom user name under which the process will be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Terminal
+If specified, terminal emulation will be used when starting the process.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Input
+Indicates that the stdin of the process should be kept open.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+## INPUTS
+
+### System.String[]
+System.String
+Docker.DotNet.Models.ContainerListResponse
+## OUTPUTS
+
+### Docker.DotNet.Models.ContainerListResponse
+
+## NOTES
+
+## RELATED LINKS
+

--- a/src/Docker.PowerShell/Objects/ContainerOperations.cs
+++ b/src/Docker.PowerShell/Objects/ContainerOperations.cs
@@ -11,7 +11,7 @@ namespace Docker.PowerShell.Objects
     public enum IsolationType
     {
         Default,
-        None,
+        Process,
         HyperV
     }
 

--- a/src/Docker.PowerShell/Support/MultiplexedStreamExtensions.cs
+++ b/src/Docker.PowerShell/Support/MultiplexedStreamExtensions.cs
@@ -3,13 +3,12 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet;
-using Docker.DotNet.Models;
 
 namespace Docker.PowerShell.Support
 {
     internal static class MultiplexedStreamExtensions
     {
-        public static async Task CopyToConsoleAsync(this MultiplexedStream stream, Config config, CancellationToken cancellationToken)
+        public static async Task CopyToConsoleAsync(this MultiplexedStream stream, bool tty, bool openStdin, CancellationToken cancellationToken)
         {
             Stream stdin = Stream.Null, stdout = Stream.Null, stderr = Stream.Null;
             ConsoleStream conin = null, conout = null;
@@ -18,7 +17,7 @@ namespace Docker.PowerShell.Support
                 // TODO: What if we are not attached to a console? If config.Tty is false, this should not be an error.
                 conout = new ConsoleStream(ConsoleDirection.Out);
                 stdout = Console.OpenStandardOutput(); // Don't use conout's Stream because FileStream always buffers on net46.
-                if (config.Tty)
+                if (tty)
                 {
                     conout.EnableVTMode();
                 }
@@ -29,12 +28,12 @@ namespace Docker.PowerShell.Support
 
                 Task stdinRead = null;
                 CancellationTokenSource inputCancelToken = null;
-                if (config.OpenStdin)
+                if (openStdin)
                 {
                     conin = new ConsoleStream(ConsoleDirection.In);
                     stdin = conin.Stream;
                     conin.EnableRawInputMode();
-                    if (config.Tty)
+                    if (tty)
                     {
                         conin.EnableVTMode();
                     }

--- a/src/Docker.PowerShell/project.json
+++ b/src/Docker.PowerShell/project.json
@@ -5,8 +5,8 @@
     "win": {}
   },
   "dependencies": {
-    "Docker.DotNet.X509": "2.124.1",
-    "Docker.DotNet": "2.124.1",
+    "Docker.DotNet.X509": "2.124.2",
+    "Docker.DotNet": "2.124.2",
     "Tar": "0.1.0-*",
     "Microsoft.PowerShell.5.ReferenceAssemblies": "1.0.0"
   },


### PR DESCRIPTION
@jstarks @jterry75 
This adds Start-ContainerProcess (alias Exec-Container) which will create a new process in the given container and attach to it.  It adds a placeholder help file (details and examles to be filled in later) and fixes a few minor bugs too.

This change updates to 2.124.2 of Docker.DotNet.