### PR TITLE
Adding support for image save/load.

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/ExportContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/ExportContainerImage.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using System.Management.Automation;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsData.Export, "ContainerImage",
+            DefaultParameterSetName = CommonParameterSetNames.Default)]
+    [Alias("Save-ContainerImage")]
+    public class ExportContainerImage : ImageOperationCmdlet
+    {
+        #region Parameters
+
+        [Parameter(Position = 1,
+            Mandatory = true)]
+        [ValidateNotNullOrEmpty]
+        public string DestinationFilePath { get; set; }
+
+        #endregion
+
+        #region Overrides
+
+        protected override async Task ProcessRecordAsync()
+        {
+            var filePath = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, DestinationFilePath);
+            var names = new List<string>(ParameterResolvers.GetImageIds(Image, Id));
+
+            using (var fs = File.Create(filePath))
+            using (var stream = await DkrClient.Miscellaneous.GetImagesAsTarballAsync(names.ToArray(), CmdletCancellationToken))
+            using (CmdletCancellationToken.Register(() => stream.Close()))
+            {
+                await stream.CopyToAsync(fs);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/ImportContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/ImportContainerImage.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using System.Management.Automation;
+using Docker.DotNet.Models;
+using System.IO;
+using Newtonsoft.Json;
+using System.Text;
+using System.Linq;
+using Docker.PowerShell.Objects;
+
+namespace Docker.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsData.Import, "ContainerImage",
+            DefaultParameterSetName = CommonParameterSetNames.Default)]
+    [Alias("Load-ContainerImage")]
+    [OutputType(typeof(ImagesListResponse))]
+    public class ImportContainerImage : DkrCmdlet
+    {
+        private const string LoadedImage = "Loaded image: ";
+
+        #region Parameters
+
+        [Parameter(Position = 0,
+            Mandatory = true)]
+        [ValidateNotNullOrEmpty]
+        public string[] FilePath { get; set; }
+
+        #endregion
+
+        #region Overrides
+
+        protected override async Task ProcessRecordAsync()
+        {
+            foreach (var item in FilePath)
+            {
+                var filePath = System.IO.Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, item);
+
+                string imageId = null;
+                bool failed = false;
+
+                using (var file = File.OpenRead(filePath))
+                {
+                    var loadTask = DkrClient.Miscellaneous.LoadImageFromTarball(file, new ImageLoadParameters { Quiet = false }, CmdletCancellationToken);
+
+                    var messageWriter = new JsonMessageWriter(this);
+
+                    using (var pushStream = await loadTask)
+                    {
+                        // ReadLineAsync is not cancellable without closing the whole stream, so register a callback to do just that.
+                        using (CmdletCancellationToken.Register(() => pushStream.Close()))
+                        using (var pullReader = new StreamReader(pushStream, new UTF8Encoding(false)))
+                        {
+                            string line;
+                            while ((line = await pullReader.ReadLineAsync()) != null)
+                            {
+                                var message = JsonConvert.DeserializeObject<JsonMessage>(line);
+                                if (message.Stream != null && message.Stream.StartsWith(LoadedImage))
+                                {
+                                    // This is probably the image ID.
+                                    imageId = message.Stream.Substring(LoadedImage.Length).Trim();
+                                }
+
+                                if (message.Error != null)
+                                {
+                                    failed = true;
+                                }
+
+                                messageWriter.WriteJsonMessage(JsonConvert.DeserializeObject<JsonMessage>(line));
+                            }
+                        }
+                    }
+
+                    messageWriter.ClearProgress();
+                    if (imageId != null)
+                    {
+                        WriteObject((await ContainerOperations.GetImagesByRepoTag(imageId, DkrClient)).Single());
+                    }
+                    else if (!failed)
+                    {
+                        throw new Exception("Could not find image, but no error was returned");
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Docker.PowerShell/Cmdlets/NewContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/NewContainerImage.cs
@@ -17,7 +17,7 @@ namespace Docker.PowerShell.Cmdlets
     [OutputType(typeof(ImagesListResponse))]
     public class NewContainerImage : DkrCmdlet
     {
-        private string _successfullyBuilt = "Successfully built ";
+        private string SuccessfullyBuilt = "Successfully built ";
 
         #region Parameters
 
@@ -125,10 +125,10 @@ namespace Docker.PowerShell.Cmdlets
                         while ((line = await buildReader.ReadLineAsync()) != null)
                         {
                             var message = JsonConvert.DeserializeObject<JsonMessage>(line);
-                            if (message.Stream != null && message.Stream.StartsWith(_successfullyBuilt))
+                            if (message.Stream != null && message.Stream.StartsWith(SuccessfullyBuilt))
                             {
                                 // This is probably the image ID.
-                                imageId = message.Stream.Substring(_successfullyBuilt.Length).Trim();
+                                imageId = message.Stream.Substring(SuccessfullyBuilt.Length).Trim();
                             }
 
                             if (message.Error != null)

--- a/src/Docker.PowerShell/Cmdlets/RequestContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/RequestContainerImage.cs
@@ -12,12 +12,12 @@ namespace Docker.PowerShell.Cmdlets
 {
     [Cmdlet(VerbsLifecycle.Request, "ContainerImage",
             DefaultParameterSetName = CommonParameterSetNames.Default)]
-    [OutputType(typeof(ContainerListResponse))]
+    [OutputType(typeof(ImagesListResponse))]
     [Alias("Pull-ContainerImage")]
     public class RequestContainerImage : DkrCmdlet
     {
-        private const string _statusUpToDate = "Status: Image is up to date for ";
-        private const string _statusDownloadedNewer = "Status: Downloaded newer image for ";
+        private const string StatusUpToDate = "Status: Image is up to date for ";
+        private const string StatusDownloadedNewer = "Status: Downloaded newer image for ";
 
         [Parameter(ParameterSetName = CommonParameterSetNames.Default,
             ValueFromPipeline = true,
@@ -57,15 +57,15 @@ namespace Docker.PowerShell.Cmdlets
                         var message = JsonConvert.DeserializeObject<JsonMessage>(line);
                         if (message.Status != null)
                         {
-                            if (message.Status.StartsWith(_statusUpToDate))
+                            if (message.Status.StartsWith(StatusUpToDate))
                             {
                                 // This is probably the image repository:tag.
-                                repoTag = message.Status.Substring(_statusUpToDate.Length).Trim();
+                                repoTag = message.Status.Substring(StatusUpToDate.Length).Trim();
                             }
-                            else if (message.Status.StartsWith(_statusDownloadedNewer))
+                            else if (message.Status.StartsWith(StatusDownloadedNewer))
                             {
                                 // This is probably the image repository:tag.
-                                repoTag = message.Status.Substring(_statusDownloadedNewer.Length).Trim();
+                                repoTag = message.Status.Substring(StatusDownloadedNewer.Length).Trim();
                             }
                         }
 

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -39,11 +39,13 @@ CmdletsToExport = @(
     'ConvertTo-ContainerImage',
     'Copy-ContainerFile',
     'Enter-ContainerSession',
+    'Export-ContainerImage',
     'Get-Container',
     'Get-ContainerDetail',
     'Get-ContainerImage',
     'Get-ContainerNet',
     'Get-ContainerNetDetail',
+    'Import-ContainerImage',
     'New-Container',
     'New-ContainerImage',
     'New-ContainerNet',
@@ -67,9 +69,11 @@ AliasesToExport = @(
     'Build-ContainerImage',
     'Commit-Container',
     'Exec-Container',
+    'Load-ContainerImage',
     'Pull-ContainerImage',
     'Push-ContainerImage',
     'Run-ContainerImage',
+    'Save-ContainerImage',
     'Tag-ContainerImage'
 )
 

--- a/src/Docker.PowerShell/Help/Export-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Export-ContainerImage.md
@@ -1,0 +1,124 @@
+---
+external help file: Docker.PowerShell.dll-Help.xml
+online version: https://github.com/Microsoft/Docker-PowerShell
+schema: 2.0.0
+---
+
+# Export-ContainerImage
+## SYNOPSIS
+{{Fill in the Synopsis}}
+## SYNTAX
+
+### Default (Default)
+```
+Export-ContainerImage -DestinationFilePath <String> [-Id] <String[]> [-HostAddress <String>]
+ [-CertificateLocation <String>] [<CommonParameters>]
+```
+
+### ImageObject
+```
+Export-ContainerImage -DestinationFilePath <String> [-Image] <ImagesListResponse[]> [-HostAddress <String>]
+ [-CertificateLocation <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+## PARAMETERS
+
+### -CertificateLocation
+{{Fill CertificateLocation Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAddress
+{{Fill HostAddress Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+{{Fill Id Description}}
+
+```yaml
+Type: String[]
+Parameter Sets: Default
+Aliases: ImageName
+
+Required: True
+Position: 0
+Default value: 
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Image
+{{Fill Image Description}}
+
+```yaml
+Type: ImagesListResponse[]
+Parameter Sets: ImageObject
+Aliases: 
+
+Required: True
+Position: 0
+Default value: 
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -DestinationFilePath
+{{Fill DestinationFilePath Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+## INPUTS
+
+### System.String[]
+Docker.DotNet.Models.ImagesListResponse[]
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/src/Docker.PowerShell/Help/Import-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Import-ContainerImage.md
@@ -1,0 +1,87 @@
+---
+external help file: Docker.PowerShell.dll-Help.xml
+online version: 
+schema: 2.0.0
+---
+
+# Import-ContainerImage
+## SYNOPSIS
+{{Fill in the Synopsis}}
+## SYNTAX
+
+```
+Import-ContainerImage [-FilePath] <String[]> [-HostAddress <String>] [-CertificateLocation <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+## PARAMETERS
+
+### -CertificateLocation
+{{Fill CertificateLocation Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+{{Fill FilePath Description}}
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: 0
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HostAddress
+{{Fill HostAddress Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Docker.DotNet.Models.ImagesListResponse
+
+## NOTES
+
+## RELATED LINKS
+

--- a/src/Docker.PowerShell/Help/Request-ContainerImage.md
+++ b/src/Docker.PowerShell/Help/Request-ContainerImage.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Docker.DotNet.Models.ContainerListResponse
+### Docker.DotNet.Models.ImagesListResponse
 
 ## NOTES
 


### PR DESCRIPTION
@jstarks @jterry75 
The new cmdlets Export/Import-ContainerImage (aliased to Save/Load-ContainerImage respectively) can save or restore images from a tar file.
Includes a fix to the return type of Request-ContainerImage.