### PR TITLE
Updating the version to 0.1.0.0 for release.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.0.0.{build}'
+version: '0.1.0.{build}'
 pull_requests:
   do_not_increment_build_number: true
 init:
@@ -35,10 +35,10 @@ build_script:
     $manifest = "src\Docker.PowerShell\Docker.psd1"
     (Get-Content $manifest -Raw) -replace "ModuleVersion.+","ModuleVersion = '$psversion'" | Out-File $manifest
 - ps: dotnet restore
-- ps: dotnet build **/project.json
+- ps: dotnet build src/Docker.PowerShell/project.json
 - ps: dotnet publish -f net46 -o $pwd\bin\net46 -c Release $pwd\src\Docker.PowerShell
-- ps: New-ExternalHelp -Path src\Docker.PowerShell\Help -OutputPath bin\en-US
 - ps: dotnet publish -f netstandard1.6 -o $pwd\bin\netstandard1.6 -c Release $pwd\src\Docker.PowerShell
+- ps: New-ExternalHelp -Path src\Docker.PowerShell\Help -OutputPath bin\en-US
 - ps: nuget pack src/Docker.PowerShell/Docker.nuspec -BasePath bin -OutputDirectory bin -Symbols -Version $psversion
 test_script:
 - ps: Register-PSRepository -Name test -SourceLocation $pwd\bin

--- a/src/Docker.PowerShell/Docker.nuspec
+++ b/src/Docker.PowerShell/Docker.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Docker</id>
-    <version>0.0.0.0</version>
+    <version>0.1.0.0</version>
     <authors>Microsoft</authors>
     <owners>microsoft</owners>
     <licenseUrl>https://raw.githubusercontent.com/Microsoft/Docker-PowerShell/master/LICENSE</licenseUrl>

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -10,7 +10,7 @@
 RootModule = "Docker.psm1"
 
 # Version number of this module.
-ModuleVersion = '0.0.0.0'
+ModuleVersion = '0.1.0.0'
 
 # Minimum PowerShell version. This should match the reference assembly version
 # in project.json (we require 5.0 due to dependencies on parameter completion).

--- a/src/Docker.PowerShell/project.json
+++ b/src/Docker.PowerShell/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0-alpha",
+  "version": "0.1.0-alpha",
   "description": "Docker.PowerShell Cmdlet Library",
   "dependencies": {
     "Docker.DotNet.X509": "2.124.2",


### PR DESCRIPTION
@jterry75 @jstarks 
This also updates the appveyor build number, and cleans up the appveyor build a bit.