### PR TITLE
Removing net46 section from Tar project.json

### DIFF
--- a/src/Tar/project.json
+++ b/src/Tar/project.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       }
-    },
-    "net46": {}
+    }
   }
 }


### PR DESCRIPTION
This is needed in order to force inclusion of depended dlls that are not present by default on PowerShell 5.0 clients.