### PR TITLE
Adding WMF 5.1 install step to appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,18 @@
 version: '0.1.0.{build}'
 pull_requests:
   do_not_increment_build_number: true
-image: WMF 5
+image: Visual Studio 2015
 init:
 - ps: Install-PackageProvider NuGet -Force
 - ps: (new-object net.webclient).DownloadFile('https://dotnetcli.blob.core.windows.net/dotnet/Sdk/rel-1.0.0/dotnet-dev-win-x64.latest.exe', "c:/dotnet-install.exe")
-- ps: Start-Process c:\dotnet-install.exe -ArgumentList "/install","/quiet" -Wait
+- cmd: c:\dotnet-install.exe /install /quiet
 install:
 - ps: Install-Module platyPS -Force
 - cmd: git submodule update --init --recursive
 nuget:
   disable_publish_on_pr: true
 build_script:
-- ps: $psversiontable
+- ps: $psversiontable | fl *
 - ps: dotnet --version
 - ps: get-packageprovider nuget
 - ps: ipmo platyPS ; get-module -name platyPS

--- a/src/Tar/project.json
+++ b/src/Tar/project.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       }
-    },
-    "net46": {}
+    }
   }
 }


### PR DESCRIPTION
This will be necessary if/when we rev the minimum powershell version for the cmdlet to 5.1.