### PR TITLE
Fixing binary module load on 5.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ image: WMF 5
 init:
 - ps: Install-PackageProvider NuGet -Force
 - ps: (new-object net.webclient).DownloadFile('https://dotnetcli.blob.core.windows.net/dotnet/Sdk/rel-1.0.0/dotnet-dev-win-x64.latest.exe', "c:/dotnet-install.exe")
-- ps: Start-Process c:\dotnet-install.exe -ArgumentList "/install","/quiet" -Wait
+- cmd: c:\dotnet-install.exe /install /quiet
 install:
 - ps: Install-Module platyPS -Force
 - cmd: git submodule update --init --recursive
@@ -48,6 +48,10 @@ test_script:
 - ps: Register-PSRepository -Name test -SourceLocation $pwd\bin
 - ps: Install-Module -Name Docker -Repository test -Force
 - ps: Import-Module Docker
+- ps: |
+    if (!(gcm -Module Docker)){
+      throw "Module failed to load: no commands found."
+    }
 - ps: git checkout -- src/Docker.PowerShell/Docker.psd1
 - ps: git checkout -- src/Docker.PowerShell/project.json
 - ps: git config core.autocrlf true

--- a/src/Docker.PowerShell/Docker.psm1
+++ b/src/Docker.PowerShell/Docker.psm1
@@ -14,7 +14,7 @@ $PSModuleRoot = $PSModule.ModuleBase
 
 # Import the appropriate nested binary module based on the current PowerShell version
 $binaryModuleRoot = $PSModuleRoot
-if ($PSVersionTable["PSEdition"] -ne 'Desktop')
+if ($PSVersionTable["PSEdition"] -eq 'Core')
 {
     $binaryModuleRoot = Join-Path -Path $PSModuleRoot -ChildPath 'coreclr'
 }


### PR DESCRIPTION
The "PSEdition" property we were checking for doesn't exist in PowerShell 5.0, which caused us to incorrectly try to load coreclr binaries on 5.0.  Also changing appveyor.yml to run dotnet cli install directly instead of launching another process and waiting.