### PR TITLE
Updating build mechanisms to work for tagging.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.1.0.{build}'
+version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 image: WMF 5
@@ -19,22 +19,22 @@ build_script:
 - ps: |
     $env:PATH = "c:\program files\dotnet;$env:PATH"
 
-    $version = $env:APPVEYOR_BUILD_VERSION
-    if ($env:APPVEYOR_REPO_TAG -eq "true") {
-      # Tags do not get build versions.
-      $version = $version.Remove($version.LastIndexOf(".")) + ".0"
-    }
-
-    # PowerShell does not support prerelease versions
-    $psversion = $version.Split("-")[0]
-
     $projectFile = "src\Docker.PowerShell\project.json"
     $project =  Get-Content $projectFile -Raw | ConvertFrom-Json
-    $project.version = $version
-    ConvertTo-Json $project -Depth 100 | Out-File -Encoding UTF8 $projectFile
+    $version = $project.version
 
+    # Tags do not get build versions.
+    if ($env:APPVEYOR_REPO_TAG -ne "true") {
+      $version += ".$($env:APPVEYOR_BUILD_VERSION.split("-")[0])"
+
+      # Update the project.json version to include the build number.
+      $project.version = $version
+      ConvertTo-Json $project -Depth 100 | Out-File -Encoding UTF8 $projectFile
+    }
+
+    # Replace module manifest version.
     $manifest = "src\Docker.PowerShell\Docker.psd1"
-    (Get-Content $manifest -Raw) -replace "ModuleVersion.+","ModuleVersion = '$psversion'" | Out-File $manifest
+    (Get-Content $manifest -Raw) -replace "ModuleVersion.+","ModuleVersion = '$version'" | Out-File $manifest
     
     Get-Content $projectFile
     Get-Content $manifest
@@ -43,7 +43,7 @@ build_script:
 - ps: dotnet publish -f net46 -o $pwd\bin\net46 -c Release $pwd\src\Docker.PowerShell
 - ps: dotnet publish -f netstandard1.6 -o $pwd\bin\netstandard1.6 -c Release $pwd\src\Docker.PowerShell
 - ps: New-ExternalHelp -Path src\Docker.PowerShell\Help -OutputPath bin\en-US
-- ps: nuget pack src/Docker.PowerShell/Docker.nuspec -BasePath bin -OutputDirectory bin -Symbols -Version $psversion
+- ps: nuget pack src/Docker.PowerShell/Docker.nuspec -BasePath bin -OutputDirectory bin -Symbols -Version $version
 test_script:
 - ps: Register-PSRepository -Name test -SourceLocation $pwd\bin
 - ps: Install-Module -Name Docker -Repository test -Force
@@ -54,6 +54,7 @@ test_script:
     }
 - ps: git checkout -- src/Docker.PowerShell/Docker.psd1
 - ps: git checkout -- src/Docker.PowerShell/project.json
+- ps: git checkout -- src/Docker.PowerShell/Docker.nuspec
 - ps: git config core.autocrlf true
 - ps: New-MarkdownHelp -Module Docker -OutputFolder src\Docker.PowerShell\Help -ErrorAction SilentlyContinue
 - ps: Update-MarkdownHelp -Path src\Docker.PowerShell\Help

--- a/src/Docker.PowerShell/Docker.nuspec
+++ b/src/Docker.PowerShell/Docker.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Docker</id>
-    <version>0.1.0.0</version>
+    <version>0.0.0</version>
     <authors>Microsoft</authors>
     <owners>microsoft</owners>
     <licenseUrl>https://raw.githubusercontent.com/Microsoft/Docker-PowerShell/master/LICENSE</licenseUrl>

--- a/src/Docker.PowerShell/Docker.psd1
+++ b/src/Docker.PowerShell/Docker.psd1
@@ -9,8 +9,8 @@
 # Script module or binary module file associated with this manifest
 RootModule = "Docker.psm1"
 
-# Version number of this module.
-ModuleVersion = '0.1.0.0'
+# Version number of this module. Gets replaced by appveyor at build time.
+ModuleVersion = '0.0.0'
 
 # Minimum PowerShell version. This should match the reference assembly version
 # in project.json (we require 5.0 due to dependencies on parameter completion).

--- a/src/Docker.PowerShell/project.json
+++ b/src/Docker.PowerShell/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-alpha",
+  "version": "0.1.0",
   "description": "Docker.PowerShell Cmdlet Library",
   "dependencies": {
     "Docker.DotNet.X509": "2.124.2",


### PR DESCRIPTION
@jstarks 
This change introduces a new approach for versioning the project:

 - The build version in the project.json file is the official central version, and must be of the form Major.Minor.Revision. No prerelease additions (ie: "-alpha") supported since PowerShell doesn't support them.

 - All other versions (.nuspec package metadata, .psd1 module metadata) remain at 0.0.0, which represents the version for local developer builds.

 - At AppVeyor build time, the project.json version is written into the .nuspec and .psd1 files.  If this is a non-tagged build, it is a developer feed build and will include a build number in the version (dynamically added to the project.json as well), making the full version format Major.Minor.Revision.Build.  The build number will not be included for tagged release builds.