### PR TITLE
Updates to the latest Docker.DotNet Start fix.

### DIFF
--- a/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
+++ b/src/Docker.PowerShell/Cmdlets/InvokeContainerImage.cs
@@ -84,8 +84,7 @@ namespace Docker.PowerShell.Cmdlets
                             streamTask = stream.CopyToConsoleAsync(Terminal, Input, CmdletCancellationToken);
                         }
 
-                        if (!await DkrClient.Containers.StartContainerAsync(
-                            createResult.ID, HostConfiguration))
+                        if (!await DkrClient.Containers.StartContainerAsync(createResult.ID, new ContainerStartParameters()))
                         {
                             throw new ApplicationFailedException("The container has already started.");
                         }

--- a/src/Docker.PowerShell/Cmdlets/StartContainer.cs
+++ b/src/Docker.PowerShell/Cmdlets/StartContainer.cs
@@ -28,8 +28,7 @@ namespace Docker.PowerShell.Cmdlets
         {
             foreach (var id in ParameterResolvers.GetContainerIds(Container, Id))
             {
-                if (!await DkrClient.Containers.StartContainerAsync(
-                        id, new HostConfig()))
+                if (!await DkrClient.Containers.StartContainerAsync(id, new ContainerStartParameters()))
                 {
                     throw new ApplicationFailedException("The container has already started.");
                 }

--- a/src/Docker.PowerShell/Objects/ContainerOperations.cs
+++ b/src/Docker.PowerShell/Objects/ContainerOperations.cs
@@ -17,7 +17,7 @@ namespace Docker.PowerShell.Objects
 
     public class ContainerProcessExitException : Exception
     {
-        public ContainerProcessExitException(long exitCode) : base(String.Format("Container process exited with non-zero exit code: {0}", exitCode)) { }
+        public ContainerProcessExitException(long exitCode) : base(string.Format("Container process exited with non-zero exit code: {0}", exitCode)) { }
     }
 
     internal static class ContainerOperations
@@ -34,13 +34,9 @@ namespace Docker.PowerShell.Objects
             CreateContainerCmdlet cmdlet,
             DotNet.DockerClient dkrClient)
         {
-            var configuration = cmdlet.Configuration;
-            if (configuration == null)
-            {
-                configuration = new Config();
-            }
+            var configuration = cmdlet.Configuration ?? new Config();
 
-            if (!String.IsNullOrEmpty(id))
+            if (!string.IsNullOrEmpty(id))
             {
                 configuration.Image = id;
             }
@@ -50,13 +46,9 @@ namespace Docker.PowerShell.Objects
                 configuration.Cmd = cmdlet.Command;
             }
 
-            var hostConfiguration = cmdlet.HostConfiguration;
-            if (hostConfiguration == null)
-            {
-                hostConfiguration = new HostConfig();
-            }
+            var hostConfiguration = cmdlet.HostConfiguration ?? new HostConfig();
 
-            if (String.IsNullOrEmpty(hostConfiguration.Isolation))
+            if (string.IsNullOrEmpty(hostConfiguration.Isolation))
             {
                 hostConfiguration.Isolation = cmdlet.Isolation.ToString();
             }


### PR DESCRIPTION
1. Updates the code to not pass the HostConfig on start as this is not
supported anylonger and doesnt make sense. Instead this is passed only at
create which was already being done in the appropriate cases.