### PR TITLE
Forcing appveyor to use older nuget

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 image: WMF 5
 init:
-- ps: Install-PackageProvider NuGet -Force
+- ps: Install-PackageProvider NuGet -Force -RequiredVersion 2.8.5.206
 - ps: (new-object net.webclient).DownloadFile('https://dotnetcli.blob.core.windows.net/dotnet/Sdk/rel-1.0.0/dotnet-dev-win-x64.latest.exe', "c:/dotnet-install.exe")
 - cmd: c:\dotnet-install.exe /install /quiet
 install:


### PR DESCRIPTION
This avoids the issue from https://github.com/PowerShell/PowerShell/issues/2331 and should allow our import and verify logic to keep working.