### PR TITLE
Adding CurrentUser scope to module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ build, in PowerShell 5.0 run:
 
     > Register-PSRepository -Name DockerPS-Dev -SourceLocation https://ci.appveyor.com/nuget/docker-powershell-dev
 
-    > Install-Module Docker -Repository DockerPS-Dev
+    > Install-Module Docker -Repository DockerPS-Dev -Scope CurrentUser
 (Note: if you get an error like "WARNING: MSG:SourceLocationNotValid" try updating your Nu-Get version as explained in [this issue comment](https://github.com/Microsoft/Docker-PowerShell/issues/62#issuecomment-221659534).)
 
 After this, you can update to new development builds with just:


### PR DESCRIPTION
User shouldn't need administrative rights (root) to install the module.

Cheers,
**Trevor Sullivan**
Docker Captain
Microsoft MVP: Cloud & Data Center Management
https://trevorsullivan.net
https://twitter.com/pcgeek86