### PR TITLE
Adding TLS verify support & key.pem support.

### DIFF
--- a/Docker.PowerShell.sln
+++ b/Docker.PowerShell.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Docker.PowerShell", "src\Docker.PowerShell\Docker.PowerShell.xproj", "{AD2C487D-EC48-4B97-A977-4C2B52E097BF}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Tar", "src\dotnet-tar\src\Tar\Tar.xproj", "{FAC0B799-8BF2-4FCE-8867-D717867403A1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CDFD41E7-FB95-44DD-866D-2461321EAEFE}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,6 +13,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Docker.DotNet", "src\Docker.DotNet\Docker.DotNet\Docker.DotNet.xproj", "{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FD49E869-E8F2-4E40-837D-E0329F087D4A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Docker.DotNet.X509", "src\Docker.DotNet\Docker.DotNet.X509\Docker.DotNet.X509.xproj", "{3EB8C108-EAD7-4A58-AACF-33D9149F4708}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Tar", "src\Tar\Tar.xproj", "{FAC0B799-8BF2-4FCE-8867-D717867403A1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,21 +28,26 @@ Global
 		{AD2C487D-EC48-4B97-A977-4C2B52E097BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD2C487D-EC48-4B97-A977-4C2B52E097BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD2C487D-EC48-4B97-A977-4C2B52E097BF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EB8C108-EAD7-4A58-AACF-33D9149F4708}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EB8C108-EAD7-4A58-AACF-33D9149F4708}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EB8C108-EAD7-4A58-AACF-33D9149F4708}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EB8C108-EAD7-4A58-AACF-33D9149F4708}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAC0B799-8BF2-4FCE-8867-D717867403A1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{AD2C487D-EC48-4B97-A977-4C2B52E097BF} = {FD49E869-E8F2-4E40-837D-E0329F087D4A}
-		{FAC0B799-8BF2-4FCE-8867-D717867403A1} = {FD49E869-E8F2-4E40-837D-E0329F087D4A}
 		{A9C3E587-DDEC-494B-96E2-BFB4FC34EC74} = {FD49E869-E8F2-4E40-837D-E0329F087D4A}
+		{3EB8C108-EAD7-4A58-AACF-33D9149F4708} = {FD49E869-E8F2-4E40-837D-E0329F087D4A}
+		{FAC0B799-8BF2-4FCE-8867-D717867403A1} = {FD49E869-E8F2-4E40-837D-E0329F087D4A}
 	EndGlobalSection
 EndGlobal

--- a/src/Docker.PowerShell/Docker.PowerShell.xproj
+++ b/src/Docker.PowerShell/Docker.PowerShell.xproj
@@ -4,22 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>ad2c487d-ec48-4b97-a977-4c2b52e097bf</ProjectGuid>
     <RootNamespace>Docker.PowerShell</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
+
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Docker.DotNet\Docker.DotNet\Docker.DotNet.xproj" />
-    <ProjectReference Include="..\dotnet-tar\src\Tar\Tar.xproj" />
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Docker.PowerShell/project.json
+++ b/src/Docker.PowerShell/project.json
@@ -2,8 +2,8 @@
   "version": "0.1.0",
   "description": "Docker.PowerShell Cmdlet Library",
   "dependencies": {
-    "Docker.DotNet.X509": "2.124.2",
-    "Docker.DotNet": "2.124.2",
+    "Docker.DotNet.X509": "2.124.3",
+    "Docker.DotNet": "2.124.3",
     "Tar": "0.1.0-*"
   },
   "frameworks": {

--- a/src/Tar/Tar.xproj
+++ b/src/Tar/Tar.xproj
@@ -4,18 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>fac0b799-8bf2-4fce-8867-d717867403a1</ProjectGuid>
     <RootNamespace>Tar</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
+
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
-  </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
@jstarks @jterry75 
With this change, the cmdlets will be able to use the ca.pem/key.pem combination in the same way as the docker CLI, removing the need for generating a separate, Windows-specific PFX.  Unforunately, the mechanisms required to make this work are not yet available in .NET Core, so certificate support is Windows only at the moment.  Once .NET Core with the latest networking fixes is released, we can unblock that scenario for cross-platform.  Pulls in the latest Docker.DotNet to get PEM support.